### PR TITLE
updated readme for requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,41 @@ Versatile Huff Project Template using Foundry.
 
 ## Getting Started
 
+### Requirements
+
+The following will need to be installed in order to use this template. Please follow the links and instructions.
+
+-   [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)  
+    -   You'll know you've done it right if you can run `git --version`
+-   [Foundry / Foundryup](https://github.com/gakonst/foundry)
+    -   This will install `forge`, `cast`, and `anvil`
+    -   You can test you've installed them right by running `forge --version` and get an output like: `forge 0.2.0 (f016135 2022-07-04T00:15:02.930499Z)`
+    -   To get the latest of each, just run `foundryup`
+-   [Huff Compiler](https://docs.huff.sh/get-started/installing/)
+    -   You'll know you've done it right if you can run `huffc --version` and get an output like: `huffc 0.2.0`
+
+### Quickstart
+
+1. Clone this repo or use template
+
 Click "Use this template" on [GitHub](https://github.com/huff-language/huff-project-template) to create a new repository with this repo as the initial state.
+
+Or run:
+
+```
+git clone https://github.com/huff-language/huff-project-template
+cd huff-project-template
+```
+
+2. Install dependencies
 
 Once you've cloned and entered into your repository, you need to install the necessary dependencies. In order to do so, simply run:
 
 ```shell
 forge install
 ```
+
+3. Build & Test
 
 To build and test your contracts, you can run:
 


### PR DESCRIPTION
Fixes: https://github.com/huff-language/huff-project-template/issues/8

It's good to have a list of requirements in users environments so they have a checklist they can refer back to if the setup process doesn't go smoothly.

Ideally we'd add some notes about what version users might need (foundry didn't always support `ffi` in the `foundry.toml`) but this gets us over the 80% line. 

Thanks for making this repo!