### PR TITLE
Upgrade 'solc_version' to `0.8.20` and set 'evm_version' to `shanghai`

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -1,6 +1,7 @@
 
 [profile.default]
-solc_version = '0.8.15'
+solc_version = '0.8.20'
+evm_version = 'shanghai'
 auto_detect_solc = false
 optimizer = true
 optimizer_runs = 200 # Default amount


### PR DESCRIPTION
## Context

After forking this template project, running forge install, and then finally testing, I was met a `EvmError: NotActivated` error. Once I did a little bit of digging, I found this comment https://github.com/foundry-rs/foundry/issues/4988#issuecomment-1556331314. After Including the following changes to the _foundry.toml_, the tests ran perfectly for me. I would like to make the same changes to this template because anyone should be able get the sample tests up and running immediately after forking

## AC

- [ ] Changes `solc_version` to `0.8.20` _(latest solc version)_
- [ ] Adds `evm_version` and sets it to `shanghai` _(where PUSH0 was introduced)_

## Additional Notes and Context

_`NotActivated` Error_
![image](https://github.com/huff-language/huff-project-template/assets/27569194/8c808821-95af-4d7a-870d-7099098ad3f5)
