### PR TITLE
Bug fix on `SimpleStore.huff`

### DIFF
--- a/src/SimpleStore.huff
+++ b/src/SimpleStore.huff
@@ -10,6 +10,9 @@
     0x04 calldataload   // [value]
     [VALUE_LOCATION]    // [ptr, value]
     sstore              // []
+
+    // End Execution
+    stop
 }
 
 #define macro GET_VALUE() = takes (0) returns (0) {


### PR DESCRIPTION
The `SET_VALUE()` macro is missing a `stop` instruction to end execution, resulting in the `GET_VALUE()` macro being accidentally executed afterwards.