### PR TITLE
fix bug in SimpleStore.huff

### DIFF
--- a/src/SimpleStore.huff
+++ b/src/SimpleStore.huff
@@ -10,6 +10,7 @@
     0x04 calldataload   // [value]
     [VALUE_LOCATION]    // [ptr, value]
     sstore              // []
+    stop                // []
 }
 
 #define macro GET_VALUE() = takes (0) returns (0) {


### PR DESCRIPTION
Previously, the `SET_VALUE()` method is not terminated correctly. Calling SET_VALUE() will continue to call `GET_VALUE()`. A `Stop` opcode need to be added at the end of `SET_VALUE()`.