### PR TITLE
bugfix: don't return the value on `setValue`

### DIFF
--- a/src/SimpleStore.huff
+++ b/src/SimpleStore.huff
@@ -10,6 +10,9 @@
     0x04 calldataload   // [value]
     [VALUE_LOCATION]    // [ptr, value]
     sstore              // []
+
+    // Exit
+    0x20 0x00 return
 }
 
 #define macro GET_VALUE() = takes (0) returns (0) {


### PR DESCRIPTION
I might be wrong, but given the function interface, `setValue` is not expected to return a value.

If we don't return on `setValue`, then `getValue` gets executed afterwards, returning `value`.

To test, you can do this:

<img width="485" alt="image" src="https://github.com/huff-language/huff-project-template/assets/38806121/267ef50f-68a6-4dfa-bcc5-2cc8478e0b26">
