### PR TITLE
Removed second dup1 in MAIN macro

### DIFF
--- a/src/SimpleStore.huff
+++ b/src/SimpleStore.huff
@@ -31,7 +31,7 @@
     // Identify which function is being called.
     0x00 calldataload 0xE0 shr
     dup1 __FUNC_SIG(setValue) eq set jumpi
-    dup1 __FUNC_SIG(getValue) eq get jumpi
+    __FUNC_SIG(getValue) eq get jumpi
 
     0x00 0x00 revert
 


### PR DESCRIPTION
`sig` created by second `dup1` is not used